### PR TITLE
Remove module * from class_create()

### DIFF
--- a/sort_mod.c
+++ b/sort_mod.c
@@ -3,6 +3,7 @@
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 
 #include "sort.h"
 
@@ -92,8 +93,11 @@ static int __init sort_init(void)
 
     if (alloc_chrdev_region(&dev, 0, 1, DEVICE_NAME) < 0)
         return -1;
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     class = class_create(THIS_MODULE, DEVICE_NAME);
+#else
+    class = class_create(DEVICE_NAME);
+#endif
     if (IS_ERR(class)) {
         goto error_unregister_chrdev_region;
     }

--- a/xoro_mod.c
+++ b/xoro_mod.c
@@ -7,6 +7,7 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 
 #define DEVICE_NAME "xoro"
 #define CLASS_NAME "xoro"
@@ -121,7 +122,11 @@ static int __init xoro_init(void)
     }
     printk(KERN_INFO "XORO:   major_number=%d\n", major_number);
 
-    dev_class = class_create(THIS_MODULE, CLASS_NAME);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+    dev_class = class_create(THIS_MODULE, DEVICE_NAME);
+#else
+    dev_class = class_create(DEVICE_NAME);
+#endif
     if (IS_ERR(dev_class)) {
         unregister_chrdev(major_number, DEVICE_NAME);  // backout
         printk(KERN_ALERT "XORO: Failed to create dev_class\n");


### PR DESCRIPTION
This commit ensures the capability with newer version of Linux Kernel. In v6.4.0 and later version of Linux Kernel, the module pointer is removed from class_create function, as it never actually did anything.

Please refer to 1aaba11da9aa7d7d6b52a74d45b31cac118295a1 commit in kernel.