### PR TITLE
Fix typo of the comment in `xoro_mod.c`

### DIFF
--- a/xoro_mod.c
+++ b/xoro_mod.c
@@ -1,4 +1,4 @@
-/* Acharacter device which returns bytes from a PRNG in the xorshiro family. */
+/* A character device which returns bytes from a PRNG in the xorshiro family. */
 
 #include <linux/device.h>
 #include <linux/fs.h>


### PR DESCRIPTION
This commit fixes a typo in the first line of `xoro_mod.c`, changing `/* Acharacter ... */` to `/* A character ...*/`.