### PR TITLE
Fix error message in read operation.

### DIFF
--- a/user.c
+++ b/user.c
@@ -25,7 +25,7 @@ int main()
 
     ssize_t r_sz = read(fd, inbuf, size);
     if (r_sz != size) {
-        perror("Failed to write character device");
+        perror("Failed to read character device");
         goto error;
     }
 


### PR DESCRIPTION
Changed error message from "Failed to write character device" to "Failed to read character device" to accurately reflect the operation being performed.