### PR TITLE
Fix uninitialized variable in error path

### DIFF
--- a/user.c
+++ b/user.c
@@ -8,17 +8,18 @@
 
 int main()
 {
+    int ret = 0;
     int fd = open(KSORT_DEV, O_RDWR);
     if (fd < 0) {
         perror("Failed to open character device");
-        goto error;
+        goto error_open;
     }
 
     size_t n_elements = 1000;
     size_t size = n_elements * sizeof(int);
     int *inbuf = malloc(size);
     if (!inbuf)
-        goto error;
+        goto error_alloc;
 
     for (size_t i = 0; i < n_elements; i++)
         inbuf[i] = rand() % n_elements;
@@ -26,11 +27,10 @@ int main()
     ssize_t r_sz = read(fd, inbuf, size);
     if (r_sz != size) {
         perror("Failed to read character device");
-        goto error;
+        goto error_read;
     }
 
     bool pass = true;
-    int ret = 0;
     /* Verify the result of sorting */
     for (size_t i = 1; i < n_elements; i++) {
         if (inbuf[i] < inbuf[i - 1]) {
@@ -41,9 +41,10 @@ int main()
 
     printf("Sorting %s!\n", pass ? "succeeded" : "failed");
 
-error:
+error_read:
     free(inbuf);
-    if (fd > 0)
-        close(fd);
+error_alloc:
+    close(fd);
+error_open:
     return ret;
 }


### PR DESCRIPTION
When an error occurs, the goto error handling path attempts to free and return variables that might not have been initialized yet. This may lead to undefined behavior or crashes.

This patch ensures variables are initialized properly before use in the error path, and avoids double-free or invalid free issues.

Observed with valgrind:
==33961== Conditional jump or move depends on uninitialised value(s)
==33961==    at 0x4849845: free
(in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==33961==    by 0x1093A7: main
(in /home/weiso131/linux_2025/ksort/user)