### PR TITLE
Add functional implementation for sort_write and sort_read

### DIFF
--- a/user.c
+++ b/user.c
@@ -28,11 +28,18 @@ int main()
     for (size_t i = 0; i < n_elements; i++)
         inbuf[i] = rand() % n_elements;
 
+    ssize_t w_sz = write(fd, inbuf, size);
+    if (w_sz != size) {
+        perror("Failed to write character device");
+        ret = EXIT_FAILURE;
+        goto error_rw;
+    }
+
     ssize_t r_sz = read(fd, inbuf, size);
     if (r_sz != size) {
         perror("Failed to read character device");
         ret = EXIT_FAILURE;
-        goto error_read;
+        goto error_rw;
     }
 
     bool pass = true;
@@ -46,7 +53,7 @@ int main()
 
     printf("Sorting %s!\n", pass ? "succeeded" : "failed");
 
-error_read:
+error_rw:
     free(inbuf);
 error_alloc:
     close(fd);


### PR DESCRIPTION
This commit introduces the actual logic for `sort_write` and `sort_read` in the kernel module. The write function stores user data in a kernel buffer, which is later sorted and returned by the read function.

Also updates the user-space test program to write data before reading, enabling end-to-end verification.

Builds on top of commit 461f45d13cf2b04013bf3594aa9969466eb7d79d. (PR #7)